### PR TITLE
always land on mornhammered

### DIFF
--- a/will_of_the_prophets/board.py
+++ b/will_of_the_prophets/board.py
@@ -37,6 +37,10 @@ def calculate_position(now):
         buttholes = get_buttholes(roll.embargo)
         special_squares = get_special_squares(roll.embargo)
 
+        # always land on mornhammered
+        if (position < 100) and ((position + roll.number) >= 100):
+            return 100
+
         position += roll.number
 
         # Handle position > 100.


### PR DESCRIPTION
Adam and Ben recently remarked on how they'd be ok if the GoB: WotP would place the runabout on the mornhammered positioned every time they reach a position > 100.

this code looks to see if the starting position is < 100, and if the roll and the ending position would be >= 100, then the ending position would be 100 (as opposed to rolling over to a low position).
